### PR TITLE
Enable vite dev workflow

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,12 @@
+export default {
+  server: {
+    port: 3000,
+    strictPort: true,
+    proxy: {
+      "/workflow": {
+        target: "http://127.0.0.1:2323",
+        changeOrigin: true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request configures a proxy in the vite dev server so devs can work on the frontend when using `npm run dev` while a server instance runs in the background.